### PR TITLE
ci: use own build script instead of calling existing `build.sh` scripts

### DIFF
--- a/.github/workflows/update-repo-3party-local.yml
+++ b/.github/workflows/update-repo-3party-local.yml
@@ -26,10 +26,23 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Clone package repositories
+      working-directory: ./3rdparty_pkgbuild
+      run: |
+        cat ./aurpackages | xargs -P $(nproc) -I {} git clone https://aur.archlinux.org/{}.git ./3rdparty/{}
+        cat ./aurpackages | xargs -P $(nproc) -I {} rm -rf ./3rdparty/{}/.git
+
     - name: Build packages
       working-directory: ./3rdparty_pkgbuild
       run: |
-        ./auto-build.sh
+        mkdir -p ../3rdparty-x86_64
+
+        for package in $(cat ./aurpackages); do
+            cd ./3rdparty/"${package}"
+            makepkg -sc --noconfirm --skippgpcheck
+            mv *.pkg.tar.zst ../../../3rdparty-x86_64
+            cd ../../
+        done
 
     - name: Verify package count
       run: |

--- a/.github/workflows/update-repo-3party-local.yml
+++ b/.github/workflows/update-repo-3party-local.yml
@@ -118,7 +118,15 @@ jobs:
     - name: Build packages
       working-directory: ./local_pkgbuild
       run: |
-        ./build.sh
+        mkdir -p ../local-x86_64
+
+        for package in ./*/; do
+            cd ./"${package}"
+            makepkg -sc --noconfirm
+            mv *.pkg.tar.zst ../../local-x86_64
+            cd ../
+        done
+
 
     - name: Verify package count
       run: |

--- a/.github/workflows/update-repo-core.yml
+++ b/.github/workflows/update-repo-core.yml
@@ -37,7 +37,14 @@ jobs:
     - name: Build packages
       working-directory: ./core_pkgbuild
       run: |
-        ./build.sh
+        mkdir -p ../core-x86_64
+
+        for package in ./*/; do
+            cd ./"${package}"
+            makepkg -sc --noconfirm
+            mv *.pkg.tar.zst ../../core-x86_64
+            cd ../
+        done
 
     - name: Verify package count
       run: |


### PR DESCRIPTION
By calling `makepkg` from the workflow itself instead of in a script called by the build step, it will fail right away when a package fails to build, allowing us to diagnose package issues faster.